### PR TITLE
bugfix: Add new line after block of definitions

### DIFF
--- a/src/checkmark_fmt/src/lib.rs
+++ b/src/checkmark_fmt/src/lib.rs
@@ -112,6 +112,26 @@ fn escape_special_characters(str: &str) -> String {
         .replace('<', "\\<")
 }
 
+/// Check that there's another definition node that follows this one.
+/// For instance:
+/// [org]: https://www.example.org
+/// [com]: https://www.example.com
+fn definition_is_followed_by_other_definition(
+    d: &markdown::mdast::Definition,
+    source: &str,
+) -> bool {
+    let line_number = d.position.as_ref().unwrap().end.line;
+    let following_line = source.lines().nth(line_number).unwrap_or_default();
+    let ast = common::ast::parse(&following_line).unwrap();
+    ast.children().is_some_and(|children| {
+        // Is there any child definition?
+        children.iter().any(|child| match child {
+            Node::Definition(_) => true,
+            _ => false,
+        })
+    })
+}
+
 /// Render Markdown file from AST
 fn to_md(
     node: &mdast::Node,
@@ -501,6 +521,19 @@ fn to_md(
             if let Some(title) = &d.title {
                 buffer.push_str(&format!(" \"{}\"", &title));
             }
+            if !definition_is_followed_by_other_definition(d, source) {
+                // We want to preserve folded definitions.
+                // For instance:
+                //    [org]: https://www.example.org
+                //    [com]: https://www.example.com
+                // should not be unfolded, so no additional
+                // newlines between definitions needed.
+                // However, we would like to add newline when
+                // there's no following definition, so we're
+                // adding newline ony when definition is not
+                // followed by another definition.
+                buffer.push('\n');
+            }
         }
         Node::LinkReference(lr) => {
             buffer.push('[');
@@ -648,4 +681,42 @@ pub fn check_md_format(
         issues.push(issue.build());
     }
     issues
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn independent_definition_correctly_detected() {
+        let source = r#"[homepage]: https://www.contributor-covenant.org"#;
+
+        let ast = common::ast::parse(&source).unwrap();
+        let only_definition = match ast.children().unwrap().first().unwrap() {
+            Node::Definition(d) => d,
+            _ => panic!("unexpected parsing result - first node is not a Definition"),
+        };
+
+        assert!(!definition_is_followed_by_other_definition(
+            only_definition,
+            source
+        ));
+    }
+
+    #[test]
+    fn definition_followed_by_other_definition_correctly_detected() {
+        let source = r#"[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html"#;
+
+        let ast = common::ast::parse(&source).unwrap();
+        let first_definition = match ast.children().unwrap().first().unwrap() {
+            Node::Definition(d) => d,
+            _ => panic!("unexpected parsing result - first node is not a Definition"),
+        };
+
+        assert!(definition_is_followed_by_other_definition(
+            first_definition,
+            source
+        ));
+    }
 }

--- a/src/checkmark_fmt/src/lib.rs
+++ b/src/checkmark_fmt/src/lib.rs
@@ -122,13 +122,12 @@ fn definition_is_followed_by_other_definition(
 ) -> bool {
     let line_number = d.position.as_ref().unwrap().end.line;
     let following_line = source.lines().nth(line_number).unwrap_or_default();
-    let ast = common::ast::parse(&following_line).unwrap();
+    let ast = common::ast::parse(following_line).unwrap();
     ast.children().is_some_and(|children| {
         // Is there any child definition?
-        children.iter().any(|child| match child {
-            Node::Definition(_) => true,
-            _ => false,
-        })
+        children
+            .iter()
+            .any(|child| matches!(child, Node::Definition(_)))
     })
 }
 
@@ -691,7 +690,7 @@ mod tests {
     fn independent_definition_correctly_detected() {
         let source = r#"[homepage]: https://www.contributor-covenant.org"#;
 
-        let ast = common::ast::parse(&source).unwrap();
+        let ast = common::ast::parse(source).unwrap();
         let only_definition = match ast.children().unwrap().first().unwrap() {
             Node::Definition(d) => d,
             _ => panic!("unexpected parsing result - first node is not a Definition"),
@@ -708,7 +707,7 @@ mod tests {
         let source = r#"[homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html"#;
 
-        let ast = common::ast::parse(&source).unwrap();
+        let ast = common::ast::parse(source).unwrap();
         let first_definition = match ast.children().unwrap().first().unwrap() {
             Node::Definition(d) => d,
             _ => panic!("unexpected parsing result - first node is not a Definition"),

--- a/src/checkmark_fmt/tests/link_tests.rs
+++ b/src/checkmark_fmt/tests/link_tests.rs
@@ -24,6 +24,10 @@ fn auto_links() {
 /// https://www.markdownguide.org/extended-syntax/#footnotes
 #[test]
 fn link_reference() {
+    // Ensure we:
+    // - Preserve link references.
+    // - Preserve folded definitions.
+    // - Do not remove newline after definitions block.
     utils::assert_unchanged_after_formatting(
         "# Attribution
 
@@ -33,6 +37,8 @@ version 2.1, available at
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+## Another header
 ",
     );
 


### PR DESCRIPTION
## Problem

When there is a definition followed by any block like this:

```markdown
[1]: https://www.example.org
[2]: https://www.example.com
## Something
```

`fmt` does not adds new line after the last defintion. Also, when in the source fie there's a definition with newline

```markdown
[2]: https://www.example.com

## Something
```

it is removed after `fmt` so it becomes this:

```markdown
[2]: https://www.example.com
## Something
```

## Solution

Handle when link definition is followed by anything except another definiton and add newline.
